### PR TITLE
Added the ability to choose port to run on

### DIFF
--- a/launch.py
+++ b/launch.py
@@ -20,19 +20,23 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
+import sys
 import webbrowser
 import SimpleHTTPServer
-import SocketServer
-import threading
+from SocketServer import TCPServer
+from threading import Thread
 
-PORT = 8000
+if sys.argv[1:]:
+    PORT = int(sys.argv[1])
+else:
+    PORT = 8000
 
 Handler = SimpleHTTPServer.SimpleHTTPRequestHandler
 
-httpd = SocketServer.TCPServer(("", PORT), Handler)
+httpd = TCPServer(("", PORT), Handler)
 
 print "Starting HTTP server on port", PORT
-threading.Thread(target=httpd.serve_forever).start()
+Thread(target=httpd.serve_forever).start()
 
 print "Launching local instance of Empress"
-webbrowser.open('http://localhost:8000')
+webbrowser.open('http://localhost:' + str(PORT))


### PR DESCRIPTION
I added the ability to choose the port that you want to run the server on. For example, to run the server on port 1234, you would do: 

```
python launch.py 1234
```

I also cleaned up some of the imports.
Great project, btw
