### PR TITLE
boostrap active link set on correct tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,8 +22,12 @@
           <a class="navbar-brand" href="/">{{App.Title}}</a>
           <div class="nav-collapse collapse">
             <ul class="nav navbar-nav">
-              <li>{{#linkTo 'index'}}Home{{/linkTo}}</li>
-              <li>{{#linkTo 'about'}}About{{/linkTo}}</li>
+                {{#linkTo 'index' tagName='li' href=false}}
+                    {{#linkTo 'index'}}Home{{/linkTo}}
+                {{/linkTo}}
+                {{#linkTo 'about' tagName='li' href=false}}
+                    {{#linkTo 'about'}}About{{/linkTo}}
+                {{/linkTo}}
             </ul>
           </div><!--/.nav-collapse -->
         </div>


### PR DESCRIPTION
With bootstrap, the active class needs to be on the li tag and not that anchor.  There was already some discussion about this on the ember project here: https://github.com/emberjs/ember.js/pull/1849.  This appears to be the suggested workaround for now.  
