### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-#Empress
+# Empress
 
 Empress is a bootstrapped blogging template that leverages [EmberJS](http://emberjs.com/) and GitHub. Empress lets you author your blog posts in [Markdown](http://daringfireball.net/projects/markdown/syntax), and uses git (and some Ruby hackery) to generate your blog on the fly. Empress leverages [Twitter Bootstrap](http://twitter.github.io/bootstrap/) to allow for easy styling.
 
 ![Empress](https://raw.github.com/hodgesmr/Empress/master/content/images/empress-screenshot.png "Empress")
 
-##Quick Start
+## Quick Start
 
 It is easy to start a local instance of Empress:
 
@@ -15,7 +15,7 @@ git clone https://github.com/hodgesmr/Empress.git ~/Empress
 
 If you want to host your Empress blog on GitHub, the following section will walk you through that.
 
-##Empress on GitHub
+## Empress on GitHub
 
 This section will walk you through setting up Empress to be your hosted GitHub user page. For more details on setting up GitHub pages, see [GitHub's documentation](https://help.github.com/categories/20/articles).
 
@@ -53,19 +53,19 @@ git fetch upstream
 git merge upstream/master
 ```
 
-##Authoring posts
+## Authoring posts
 
 Use Markdown to author your blog posts. All posts should be placed in `/content/posts/`.
 
 The Empress build process works by referencing files that have a commit in your git tree. While authoring a post (or changing any file), git commit as usual to track your changes. Once you are ready to publish your blog, add, commit, and then run `/build.rb`. **Important:** the build will fail if you have untracked files in `/content/posts/`. You can see your changes locally by running `/start.rb` and pointing your browser to localhost, before pushing.
 
-####Conventions
+#### Conventions
 
 A post's slug is determined by its filename. All post files should be named accordingly: `My-Blog-Post.md`. This tells Empress not only the resource location for your post, but also that the post slug will be `My-Blog-Post`.
 
 The post's title is defined by the first line in its Markdown file. This should be denoted using Markdown's H1 atx syntax. So, the first line of your post file should be `#My Blog Post`.
 
-##Other files
+## Other files
 
 By default, Empress references two other files when rendering its template: `/content/about.md` and `/content/externalLinks.json`. Update these as necessary. Also, update your blog's title in `app.js`.
 

--- a/content/about.md
+++ b/content/about.md
@@ -1,3 +1,3 @@
-#About
+# About
 
 This is the about page. Use it to tell readers about you and the content of your blog.

--- a/content/posts/Welcome-to-Empress.md
+++ b/content/posts/Welcome-to-Empress.md
@@ -1,8 +1,8 @@
-#Welcome to Empress!
+# Welcome to Empress!
 
 Empress is a bootstrapped blogging template that leverages [EmberJS](http://emberjs.com/) and GitHub. Empress lets you author your blog posts in [Markdown](http://daringfireball.net/projects/markdown/syntax), and uses git (and some Ruby hackery) to generate you blog on the fly.
 
-##Quick Start
+## Quick Start
 
 It is easy to launch a local instance of Empress:
 
@@ -13,7 +13,7 @@ git clone https://github.com/hodgesmr/Empress.git ~/Empress
 
 If you want to host your Empress blog on GitHub, the following section will walk you through that.
 
-##Empress on GitHub
+## Empress on GitHub
 
 This section will walk you through setting up Empress to be your hosted GitHub user page. For more details on setting up GitHub pages, see [GitHub's documentation](https://help.github.com/categories/20/articles).
 
@@ -49,19 +49,19 @@ git fetch upstream
 git merge upstream/master
 ```
 
-##Authoring posts
+## Authoring posts
 
 Use Markdown to author your blog posts. All posts should be placed in `/content/posts/`.
 
 The Empress build process works by referencing files that have a commit in your git tree. While authoring a post (or changing any file), git commit as usual to track your changes. Once you are ready to publish your blog, add, commit, and then run `/build.rb`. You can see your changes locally by running `/start.rb` and pointing your browser to localhost, before pushing.
 
-####Conventions
+#### Conventions
 
 A post's slug is determined by its filename. All post files should be named accordingly: `My-Blog-Post.md`. This tells Empress not only the resource location for your post, but also that the post slug will be `My-Blog-Post`.
 
 A post's title is defined by the first line in its Markdown file. This should be denoted using Markdown's H1 atx syntax. So, the first line of your post file should be `#My Blog Post`.
 
-##Other files
+## Other files
 
 By default, Empress references two other files when rendering its template: `/content/about.md` and `/content/externalLinks.json`. Update these as necessary.
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
